### PR TITLE
Correct spelling and link format for view more

### DIFF
--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -13,14 +13,17 @@ function generateViewMoreElement(outputId: string) {
 	second.textContent = 'size limit';
 	second.href = `command:workbench.action.openSettings?%5B%22notebook.output.textLineLimit%22%5D`;
 	const third = document.createElement('span');
-	third.textContent = '. Open the full output data';
-	const forth = document.createElement('a');
-	forth.textContent = ' in a text editor';
-	forth.href = `command:workbench.action.openLargeOutput?${outputId}`;
+	third.textContent = '. Open the full output data ';
+	const fourth = document.createElement('a');
+	fourth.textContent = 'in a text editor';
+	fourth.href = `command:workbench.action.openLargeOutput?${outputId}`;
+	const fifth = document.createElement('span');
+	fifth.textContent = '.';
 	container.appendChild(first);
 	container.appendChild(second);
 	container.appendChild(third);
-	container.appendChild(forth);
+	container.appendChild(fourth);
+	container.appendChild(fifth);
 	return container;
 }
 


### PR DESCRIPTION
This cosmetic pull request corrects the following message by changing the bounds of the anchor tag and adding a period.

Before:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/346068/188513614-de1a8457-ceb8-4ac7-a13b-2dee1782b6d5.png">

After:

<p>Output exceeds the <a href="#">file limit</a>. Open the full output data <a href="#">in a text editor</a>.</p>